### PR TITLE
Fix compilation with only blake3 enabled

### DIFF
--- a/password/Cargo.toml
+++ b/password/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["authentication"]
 edition = "2018"
 
 [features]
-default = ["sha3"]
+default = ["blake3"]
 p256 = ["p256_"]
 pbkdf2 = ["hmac", "pbkdf2_", "zeroize"]
 

--- a/password/src/cipher_suite/export_key.rs
+++ b/password/src/cipher_suite/export_key.rs
@@ -1,9 +1,6 @@
 //! See [`ExportKeyExt`].
 
-use generic_array::{
-	typenum::{U32, U64},
-	GenericArray,
-};
+use generic_array::{typenum::U64, GenericArray};
 
 /// Utility trait to help convert export key to `[u8; 64]`.
 pub(crate) trait ExportKeyExt {
@@ -12,7 +9,7 @@ pub(crate) trait ExportKeyExt {
 }
 
 #[cfg(feature = "p256")]
-impl ExportKeyExt for GenericArray<u8, U32> {
+impl ExportKeyExt for GenericArray<u8, generic_array::typenum::U32> {
 	fn into_array(self) -> [u8; 64] {
 		let mut key = [0; 64];
 		key[..32].copy_from_slice(&self);

--- a/password/src/cipher_suite/mod.rs
+++ b/password/src/cipher_suite/mod.rs
@@ -13,7 +13,7 @@ mod blake3;
 mod export_key;
 #[cfg(feature = "p256")]
 mod p256;
-#[cfg(feature = "blake3")]
+#[cfg(feature = "pbkdf2")]
 mod pbkdf2;
 mod public_key;
 

--- a/password/src/cipher_suite/public_key.rs
+++ b/password/src/cipher_suite/public_key.rs
@@ -3,8 +3,6 @@
 use curve25519_dalek::ristretto::RistrettoPoint;
 use opaque_ke::keypair::PublicKey;
 
-use super::p256::P256;
-
 /// Utility trait to help convert and compare [`opaque_ke::keypair::PublicKey`]
 /// to `[u8; 33]`.
 pub(crate) trait PublicKeyExt {
@@ -36,7 +34,7 @@ impl PublicKeyExt for PublicKey<RistrettoPoint> {
 }
 
 #[cfg(feature = "p256")]
-impl PublicKeyExt for PublicKey<P256> {
+impl PublicKeyExt for PublicKey<super::p256::P256> {
 	fn into_array(self) -> [u8; 33] {
 		(**self).into()
 	}

--- a/password/src/config.rs
+++ b/password/src/config.rs
@@ -206,8 +206,10 @@ impl Default for Hash {
 	fn default() -> Self {
 		#[cfg(feature = "sha3")]
 		return Self::Sha3;
-		#[cfg(not(feature = "sha3"))]
-		Self::Sha512
+		#[cfg(all(feature = "blake3", not(feature = "sha3")))]
+		return Self::Blake3;
+		#[cfg(all(not(feature = "sha3"), not(feature = "blake3")))]
+		return Self::Sha512;
 	}
 }
 

--- a/password/src/config.rs
+++ b/password/src/config.rs
@@ -204,12 +204,12 @@ pub enum Hash {
 
 impl Default for Hash {
 	fn default() -> Self {
-		#[cfg(feature = "sha3")]
-		return Self::Sha3;
-		#[cfg(all(feature = "blake3", not(feature = "sha3")))]
+		#[cfg(feature = "blake3")]
 		return Self::Blake3;
-		#[cfg(all(not(feature = "sha3"), not(feature = "blake3")))]
-		return Self::Sha512;
+		#[cfg(all(not(feature = "blake3"), feature = "sha3"))]
+		return Self::Sha3;
+		#[cfg(all(not(feature = "blake3"), not(feature = "sha3")))]
+		return Self::Sha2;
 	}
 }
 


### PR DESCRIPTION
This pull request allows default-features = false and features=["blake3"] to compile.

The Hash::default() implementation should probably be switched to cfg_if
to make it read more cleanly, but I didn't want to introduce the new dependency in case you disagreed.